### PR TITLE
Switch big-peer to use helm-charts Kafka chart

### DIFF
--- a/charts/big-peer/Chart.yaml
+++ b/charts/big-peer/Chart.yaml
@@ -15,7 +15,7 @@ home: https://docs.ditto.live/
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.9
+version: 0.2.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -75,8 +75,8 @@ dependencies:
     tags:
       - kafka-operator
   - name: kafka
-    version: "0.2.2"
-    repository: "oci://quay.io/ditto-external"
+    version: "0.3.0"
+    repository: "https://getditto.github.io/helm-charts/"
     alias: kafka
     condition: kafka-cluster.enabled
     tags:


### PR DESCRIPTION
The external Kafka chart has the following enhancements:
* allows setting annotations on the Kafka resource
* sets ArgoCD sync options on the KafkaNodePool PersistentVolumeClaim to prevent deletion