### PR TITLE
fix: update chart deps fixes issues with creating lqt kafka

### DIFF
--- a/charts/big-peer/Chart.lock
+++ b/charts/big-peer/Chart.lock
@@ -32,5 +32,5 @@ dependencies:
 - name: kafka
   repository: https://getditto.github.io/helm-charts/
   version: 0.3.3
-digest: sha256:c78b26699c45312db537a31949082f337cf3a17abb70f63eabe32afa1574a53e
-generated: "2024-11-27T15:20:27.251739+13:00"
+digest: sha256:66918c7a525697717672ecd1aba611de9948589250b91c9a5f9a7bdb7ed7426f
+generated: "2024-12-19T11:44:09.63629131-06:00"

--- a/charts/big-peer/Chart.lock
+++ b/charts/big-peer/Chart.lock
@@ -32,5 +32,5 @@ dependencies:
 - name: kafka
   repository: https://getditto.github.io/helm-charts/
   version: 0.3.3
-digest: sha256:66918c7a525697717672ecd1aba611de9948589250b91c9a5f9a7bdb7ed7426f
-generated: "2024-12-19T11:44:09.63629131-06:00"
+digest: sha256:dbf32fa8d6fa1346211fb86b5cf3bc9921cdf83bbe577c2c45c74ee0f6d05b63
+generated: "2024-12-19T12:05:59.366092125-06:00"

--- a/charts/big-peer/Chart.yaml
+++ b/charts/big-peer/Chart.yaml
@@ -101,3 +101,4 @@ dependencies:
     condition: live-query.enabled
     tags:
       - kafka
+      - live-query

--- a/charts/big-peer/Chart.yaml
+++ b/charts/big-peer/Chart.yaml
@@ -15,7 +15,7 @@ home: https://docs.ditto.live/
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.12
+version: 0.2.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/big-peer/values.yaml
+++ b/charts/big-peer/values.yaml
@@ -76,6 +76,8 @@ apps:
 
 # global kafka cluster options
 kafka:
+  networkPolicies: 
+    enabled: false
   # enable kraft mode for dual use Kafka nodes in a common node pool
   kraft:
     enabled: false
@@ -851,6 +853,8 @@ live-query:
     CDC_HEARTBEAT_KAFKA_REPLICATION_FACTOR: 1
 
 live-query-kafka:
+  networkPolicies: 
+    enabled: false
   # enable kraft mode for dual use Kafka nodes in a common node pool
   kraft:
     enabled: false

--- a/charts/big-peer/values.yaml
+++ b/charts/big-peer/values.yaml
@@ -76,7 +76,7 @@ apps:
 
 # global kafka cluster options
 kafka:
-  networkPolicies: 
+  networkPolicies:
     enabled: false
   # enable kraft mode for dual use Kafka nodes in a common node pool
   kraft:
@@ -853,7 +853,7 @@ live-query:
     CDC_HEARTBEAT_KAFKA_REPLICATION_FACTOR: 1
 
 live-query-kafka:
-  networkPolicies: 
+  networkPolicies:
     enabled: false
   # enable kraft mode for dual use Kafka nodes in a common node pool
   kraft:


### PR DESCRIPTION
Was finally able to replicate the issue our users were experiencing and it was because my laptop had an updated version of kafka chart that wasn't in the chart.lock a dep update fixed.

I also defaulted the network policies in kafka to disabled in the helm chart as this is not typically used in POC's and preview use cases yet.
