### PR TITLE
add: ability to select collection that live-query is scoped to, default is null/all

### DIFF
--- a/charts/big-peer/Chart.lock
+++ b/charts/big-peer/Chart.lock
@@ -22,7 +22,7 @@ dependencies:
   version: 0.44.0
 - name: kafka
   repository: https://getditto.github.io/helm-charts/
-  version: 0.3.5
+  version: 0.3.6
 - name: dummy-auth-webhook
   repository: oci://quay.io/ditto-external
   version: 0.1.1
@@ -31,6 +31,6 @@ dependencies:
   version: 0.1.0-002c59
 - name: kafka
   repository: https://getditto.github.io/helm-charts/
-  version: 0.3.5
-digest: sha256:32d2472e3b0c018b3fdfd462273c02adb7117b54a714ba13ce9be2a0888f663d
-generated: "2025-01-10T10:55:30.13758089-06:00"
+  version: 0.3.6
+digest: sha256:1db080b92f534cac8abc9c9d4bbd7840ec624318f3316f4a41a337d1dad16a7f
+generated: "2025-01-15T09:12:27.945293144-06:00"

--- a/charts/big-peer/Chart.yaml
+++ b/charts/big-peer/Chart.yaml
@@ -15,7 +15,7 @@ home: https://docs.ditto.live/
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.14
+version: 0.2.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -75,7 +75,7 @@ dependencies:
     tags:
       - kafka-operator
   - name: kafka
-    version: "0.3.5"
+    version: "0.3.6"
     repository: "https://getditto.github.io/helm-charts/"
     alias: kafka
     condition: kafka-cluster.enabled
@@ -96,7 +96,7 @@ dependencies:
       - live-query
   - name: kafka
     alias: live-query-kafka
-    version: "0.3.5"
+    version: "0.3.6"
     repository: "https://getditto.github.io/helm-charts/"
     condition: live-query.enabled
     tags:

--- a/charts/big-peer/templates/classes/_live_query_source.tpl
+++ b/charts/big-peer/templates/classes/_live_query_source.tpl
@@ -35,8 +35,8 @@ metadata:
   {{- end }}
 spec:
   appId: {{ $appValues.id }}
-  description: null
-  collection: null 
+  description: {{ $queryValues.description }}
+  collection: {{ $queryValues.collection }}
   liveQueryCoreRef:
     name: {{ $appValues.id }}
     namespace: {{ .Release.Namespace }}

--- a/charts/big-peer/values.yaml
+++ b/charts/big-peer/values.yaml
@@ -57,6 +57,8 @@ apps:
       queries:
         - name: "all_the_things"
           enabled: true
+          description: null
+          collection: null
           queryFilterExpression: "true"
           schema: untyped
           sinks:
@@ -67,6 +69,8 @@ apps:
               url: "http://myapp.com/rimshot"
         - name: "send_to_hook"
           enabled: true
+          description: null
+          collection: null
           queryFilterExpression: "true"
           schema: untyped
           sinks:
@@ -862,11 +866,15 @@ live-query-kafka:
       dualRoles: true
       replicas: 1
 
+
   # disable kafka supporting services that are not required
   strimzi:
     replicas: 3
     authorization: simple
-    external: true
+
+    externalListener:
+      enabled: false
+
 
     # interBrokerProtocolVersion: 3.8.0
     kafkaVersion: 3.8.0


### PR DESCRIPTION
Current version of chart just makes all live-query deployments query all collections this change allows the user to configure this.

Also there were some unexpected values that leaked through values in the kafka chart that were fixed this upgrades to that version.