### PR TITLE
chore(big-peer): bump kafka to 0.4.0

### DIFF
--- a/charts/big-peer/Chart.yaml
+++ b/charts/big-peer/Chart.yaml
@@ -15,7 +15,7 @@ home: https://docs.ditto.live/
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.15
+version: 0.2.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -75,7 +75,7 @@ dependencies:
     tags:
       - kafka-operator
   - name: kafka
-    version: "0.3.6"
+    version: "0.4.0"
     repository: "https://getditto.github.io/helm-charts/"
     alias: kafka
     condition: kafka-cluster.enabled
@@ -96,7 +96,7 @@ dependencies:
       - live-query
   - name: kafka
     alias: live-query-kafka
-    version: "0.3.6"
+    version: "0.4.0"
     repository: "https://getditto.github.io/helm-charts/"
     condition: live-query.enabled
     tags:


### PR DESCRIPTION
This change bumps the Kafka subchart to 0.4.0 to pickup recent support for setting KafkaNodePool resources.