### PR TITLE
feat: Change live query templating to reflect controller semantics

### DIFF
--- a/charts/big-peer/Chart.lock
+++ b/charts/big-peer/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 1.39.2-4b6e4e
 - name: hydra-subscription
   repository: oci://quay.io/ditto-external
-  version: 1.39.2-4b6e4e
+  version: 1.40.1
 - name: service-token-validator
   repository: oci://quay.io/ditto-external
   version: 0.2.1
@@ -32,5 +32,5 @@ dependencies:
 - name: kafka
   repository: https://getditto.github.io/helm-charts/
   version: 0.4.0
-digest: sha256:e6e98619c90c8fc94019f15da607903cdd70eec835cd8ba2597e8a4add41b87a
-generated: "2025-03-04T15:14:49.277798+13:00"
+digest: sha256:a8fe5a0ab8386e7b7ddab24d7379b2102f219f438cdfdd0bb77b39669d2438de
+generated: "2025-03-21T16:42:05.239999-04:00"

--- a/charts/big-peer/Chart.yaml
+++ b/charts/big-peer/Chart.yaml
@@ -15,7 +15,7 @@ home: https://docs.ditto.live/
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.17
+version: 0.2.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -51,7 +51,7 @@ dependencies:
     tags:
       - hydra-store
   - name: hydra-subscription
-    version: "1.39.2-4b6e4e"
+    version: "1.40.1"
     repository: "oci://quay.io/ditto-external"
     condition: hydra-subscription.enabled
     tags:

--- a/charts/big-peer/templates/classes/_live_query_source.tpl
+++ b/charts/big-peer/templates/classes/_live_query_source.tpl
@@ -36,7 +36,9 @@ metadata:
 spec:
   appId: {{ $appValues.id }}
   description: {{ $queryValues.description }}
+  {{- if $queryValues.collection }}
   collection: {{ $queryValues.collection }}
+  {{ end }}
   liveQueryCoreRef:
     name: {{ $appValues.id }}
     namespace: {{ .Release.Namespace }}
@@ -44,7 +46,7 @@ spec:
     kafka:
       cluster:
         name: {{ .Release.Name }}-live-query-kafka
-        namespace: {{ .Release.Namespace }} 
+        namespace: {{ .Release.Namespace }}
       topicName: {{ include "common.topics.name" (dict "id" $appValues.id "queryName" $queryValues.name) }}
   queryFilterExpression: {{ $queryValues.queryFilterExpression | quote }}
   schema: {{ $queryValues.schema }}

--- a/charts/big-peer/values.yaml
+++ b/charts/big-peer/values.yaml
@@ -830,7 +830,7 @@ live-query:
     CDC_RESOURCE_REQUEST_CPU: 40m
     CDC_RESOURCE_REQUEST_MEMORY: 1G
     CDC_RESOURCE_LIMIT_MEMORY: 4G
-    CDC_IMAGE: quay.io/ditto-external/hydra-cdc:1.39.2
+    CDC_IMAGE: quay.io/ditto-external/hydra-cdc:1.41.0
     CDC_TOKEN_AUDIENCE: cloud.ditto.live
     CDC_KAFKA_REPLICATION_FACTOR: 1
 
@@ -838,21 +838,21 @@ live-query:
     STREAM_SPLITTER_RESOURCE_REQUEST_CPU: 20m
     STREAM_SPLITTER_RESOURCE_REQUEST_MEMORY: 256Mi
     STREAM_SPLITTER_RESOURCE_LIMIT_MEMORY: 1G
-    STREAM_SPLITTER_IMAGE: quay.io/ditto-external/hydra-stream-splitter:1.39.2
+    STREAM_SPLITTER_IMAGE: quay.io/ditto-external/hydra-stream-splitter:1.41.0-55820-d33946
     STREAM_SPLITTER_TOKEN_AUDIENCE: cloud.ditto.live
 
     # WebhookDispatcher workload config
     WEBHOOK_DISPATCHER_RESOURCE_REQUEST_CPU: 20m
     WEBHOOK_DISPATCHER_RESOURCE_REQUEST_MEMORY: 24Mi
     WEBHOOK_DISPATCHER_RESOURCE_LIMIT_MEMORY: 128Mi
-    WEBHOOK_DISPATCHER_IMAGE: quay.io/ditto-external/hydra-webhook-dispatcher:1.39.2
+    WEBHOOK_DISPATCHER_IMAGE: quay.io/ditto-external/hydra-webhook-dispatcher:1.40.3
     WEBHOOK_DISPATCHER_TOKEN_AUDIENCE: cloud.ditto.live
 
     # CDC Hearbeat workload config
     CDC_HEARTBEAT_RESOURCE_REQUEST_CPU: 20m
     CDC_HEARTBEAT_RESOURCE_REQUEST_MEMORY: 50Mi
     CDC_HEARTBEAT_RESOURCE_LIMIT_MEMORY: 150Mi
-    CDC_HEARTBEAT_IMAGE: quay.io/ditto-external/cdc-heartbeat:1.39.2
+    CDC_HEARTBEAT_IMAGE: quay.io/ditto-external/cdc-heartbeat:1.41.0
     CDC_HEARTBEAT_TOKEN_AUDIENCE: cloud.ditto.live
     CDC_HEARTBEAT_KAFKA_REPLICATION_FACTOR: 1
 


### PR DESCRIPTION
Upstream of the templating, at the next domain layer for the existing Change Data Capture system, there are specific naming semantics that the Live Query controllers expect.

This templating change brings the Helm chart templates inline with what those controllers expect to prevent edge case bugs.

Related components of the CDC are updated to incorporate recent edits as well. 